### PR TITLE
Retrieve number of default retries from environment

### DIFF
--- a/lib/hound/request_utils.ex
+++ b/lib/hound/request_utils.ex
@@ -1,7 +1,9 @@
 defmodule Hound.RequestUtils do
   @moduledoc false
 
-  def make_req(type, path, params \\ %{}, options \\ %{}, retries \\ 0)
+  @retries Application.get_env(:hound, :retries, 0)
+
+  def make_req(type, path, params \\ %{}, options \\ %{}, retries \\ @retries)
   def make_req(type, path, params, options, 0) do
     send_req(type, path, params, options)
   end


### PR DESCRIPTION
This allows for the setting of default retries from the configuration. Specially useful when you are running hound on a machine that has resource starvation.